### PR TITLE
Add support for rayQueryGetIntersectionTriangleVertexPositionsEXT

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -10208,6 +10208,32 @@ ${{{{
         auto ccTF = candidateOrCommitted == 0 ? "false" : "true";
 }}}}
 
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_EXT_ray_tracing_position_fetch)
+    __glsl_version(460)
+    [__NoSideEffect]
+    void $(ccName)GetIntersectionTriangleVertexPositions(out float3 positions[3])
+    {
+        __target_switch
+        {
+        case glsl: __intrinsic_asm "rayQueryGetIntersectionTriangleVertexPositionsEXT($0, $(ccTF), $1)";
+        case spirv:
+            uint iCandidateOrCommitted = $(candidateOrCommitted);
+            let arrayLenth = 3;
+            spirv_asm
+            {
+                OpCapability RayQueryKHR;
+                OpCapability RayTracingPositionFetchKHR;
+                OpCapability RayQueryPositionFetchKHR;
+                OpExtension "SPV_KHR_ray_query";
+                OpExtension "SPV_KHR_ray_tracing_position_fetch";
+                %_arr_v3float_uint_3 = OpTypeArray $$float3 $arrayLenth;
+		        %res = OpRayQueryGetIntersectionTriangleVertexPositionsKHR %_arr_v3float_uint_3 &this $iCandidateOrCommitted;
+                OpStore &positions %res;
+            };
+        }
+    };
+
     // CandidateObjectToWorld3x4, CandidateWorldToObject4x3
     // CommittedObjectToWorld3x4, CommittedObjectToWorld4x3
     ${{{{

--- a/tests/vkray/rayquery-closesthit.slang
+++ b/tests/vkray/rayquery-closesthit.slang
@@ -1,0 +1,34 @@
+// rayquery-closesthit.slang
+//TEST:SIMPLE(filecheck=CHECK): -profile glsl_460+GL_EXT_ray_tracing -stage closesthit -entry main -target spirv-assembly
+//TEST:SIMPLE(filecheck=CHECK): -stage closesthit -entry main -target spirv-assembly -emit-spirv-directly
+
+struct IntersectionPayload
+{
+    float3 triangleVertice[3];
+};
+
+RaytracingAccelerationStructure accelerationStructure;
+
+void main(
+	BuiltInTriangleIntersectionAttributes 	attributes,
+	in out IntersectionPayload 				ioPayload)
+{
+	RayQuery<RAY_FLAG_NONE> rayQuery;
+
+	uint instanceInclusionMask = 0x00;
+	RayDesc rayDesc;
+	rayQuery.TraceRayInline(accelerationStructure, RAY_FLAG_NONE, instanceInclusionMask, rayDesc);
+
+	rayQuery.CandidateGetIntersectionTriangleVertexPositions(ioPayload.triangleVertice);
+	rayQuery.CommittedGetIntersectionTriangleVertexPositions(ioPayload.triangleVertice);
+}
+
+// CHECK: OpCapability RayQueryKHR
+// CHECK: OpCapability RayTracingPositionFetchKHR
+// CHECK: OpCapability RayQueryPositionFetchKHR
+// CHECK: OpExtension "SPV_KHR_ray_query"
+// CHECK: OpExtension "SPV_KHR_ray_tracing_position_fetch"
+// CHECK: OpEntryPoint ClosestHitNV %main "main"
+// CHECK: OpRayQueryInitializeKHR %rayQuery{{.*}}
+// CHECK: OpRayQueryGetIntersectionTriangleVertexPositionsKHR %_arr_v3float_uint_3 %rayQuery{{.*}} %{{u?}}int_0
+// CHECK: OpRayQueryGetIntersectionTriangleVertexPositionsKHR %_arr_v3float_uint_3 %rayQuery{{.*}} %{{u?}}int_1


### PR DESCRIPTION
Add a member function to RayQuery<RAY_FLAG> class
GetIntersectionTriangleVertexPositions to support the GLSL built-int rayQueryGetIntersectionTriangleVertexPositionsEXT.

Also add new test file under tests/vkray/rayquery-closesthit.slang to test this functionality.