### PR TITLE
Fix structural trace stage validation

### DIFF
--- a/docs/user-guide/a4-02-reference-capability-atoms.md
+++ b/docs/user-guide/a4-02-reference-capability-atoms.md
@@ -1532,6 +1532,9 @@ Compound Capabilities
 `structural_raytracing_miss`
 > Logical miss role used by the structural ray-tracing API.
 
+`structural_raytracing_trace`
+> Stages that may trace a ray through the structural ray-tracing API.
+
 `structuredbuffer`
 > Capabilities required to use StructuredBuffer
 

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -1593,6 +1593,13 @@ alias anyhit_intersection = anyhit | intersection;
 /// [Compound]
 alias raygen_closesthit_miss = raygen | closesthit | miss;
 
+/// Stages that may trace a ray through the structural ray-tracing API.
+/// [Compound]
+alias structural_raytracing_trace = glsl_hlsl_spirv + raygen_closesthit_miss
+                                    | _raygen + metal
+                                    | _closesthit + metal
+                                    | _miss + metal;
+
 /// Collection of shader stages
 /// [Compound]
 alias anyhit_closesthit_intersection = anyhit | closesthit | intersection;

--- a/source/standard-modules/raytracing/trace.slang
+++ b/source/standard-modules/raytracing/trace.slang
@@ -13,6 +13,7 @@ public extension<ProgramLayout> RayTracer<ProgramLayout>
     where ProgramLayout.TraceContext.Motion == NoMotion
 {
     [ForceInline]
+    [require(structural_raytracing_trace)]
     public void trace(
         RayTraversalDesc desc,
         ProgramLayout.TraceContext.AccelerationStructure accelerationStructure,
@@ -44,7 +45,7 @@ public extension<ProgramLayout> RayTracer<ProgramLayout>
     where ProgramLayout.TraceContext.Motion == PrimitiveMotion
 {
     [ForceInline]
-    [require(metallib_2_4)]
+    [require(structural_raytracing_trace, metallib_2_4)]
     public void trace(
         RayTraversalDesc desc,
         ProgramLayout.TraceContext.AccelerationStructure accelerationStructure,
@@ -61,7 +62,7 @@ public extension<ProgramLayout> RayTracer<ProgramLayout>
     where ProgramLayout.TraceContext.Motion == InstanceMotion
 {
     [ForceInline]
-    [require(metallib_2_4)]
+    [require(structural_raytracing_trace, metallib_2_4)]
     public void trace(
         RayTraversalDesc desc,
         ProgramLayout.TraceContext.AccelerationStructure accelerationStructure,
@@ -78,7 +79,7 @@ public extension<ProgramLayout> RayTracer<ProgramLayout>
     where ProgramLayout.TraceContext.Motion == PrimitiveAndInstanceMotion
 {
     [ForceInline]
-    [require(metallib_2_4)]
+    [require(structural_raytracing_trace, metallib_2_4)]
     public void trace(
         RayTraversalDesc desc,
         ProgramLayout.TraceContext.AccelerationStructure accelerationStructure,
@@ -94,7 +95,7 @@ public extension<ProgramLayout> RayTracer<ProgramLayout>
     where ProgramLayout.TraceContext.Motion == NoMotion
 {
     [ForceInline]
-    [require(metal)]
+    [require(structural_raytracing_trace, metal)]
     public void trace<let maxLevelCount : int>(
         RayTraversalDesc desc,
         MultiLevelAccelerationStructure<maxLevelCount> accelerationStructure,
@@ -112,7 +113,7 @@ public extension<ProgramLayout> RayTracer<ProgramLayout>
     where ProgramLayout.TraceContext.Motion == PrimitiveMotion
 {
     [ForceInline]
-    [require(metal)]
+    [require(structural_raytracing_trace, metal)]
     public void trace<let maxLevelCount : int>(
         RayTraversalDesc desc,
         MultiLevelAccelerationStructure<maxLevelCount> accelerationStructure,
@@ -130,7 +131,7 @@ public extension<ProgramLayout> RayTracer<ProgramLayout>
     where ProgramLayout.TraceContext.Motion == InstanceMotion
 {
     [ForceInline]
-    [require(metal)]
+    [require(structural_raytracing_trace, metal)]
     public void trace<let maxLevelCount : int>(
         RayTraversalDesc desc,
         MultiLevelAccelerationStructure<maxLevelCount> accelerationStructure,
@@ -148,7 +149,7 @@ public extension<ProgramLayout> RayTracer<ProgramLayout>
     where ProgramLayout.TraceContext.Motion == PrimitiveAndInstanceMotion
 {
     [ForceInline]
-    [require(metal)]
+    [require(structural_raytracing_trace, metal)]
     public void trace<let maxLevelCount : int>(
         RayTraversalDesc desc,
         MultiLevelAccelerationStructure<maxLevelCount> accelerationStructure,

--- a/tests/ray-tracing-2/frontend/capabilities/trace-dispatch-stage.slang
+++ b/tests/ray-tracing-2/frontend/capabilities/trace-dispatch-stage.slang
@@ -1,0 +1,56 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -entry BadAnyHit -stage anyhit -target hlsl
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -entry BadAnyHit -stage anyhit -target metal
+
+import slang.raytracing;
+
+struct Payload
+{
+    float value;
+}
+
+struct MyTraceContext : rt::ITraceContext
+{
+    typealias Payload = Payload;
+    typealias AccelerationStructure = rt::AccelerationStructure;
+    typealias Motion = rt::NoMotion;
+}
+
+struct HitContext : rt::IHitContext
+{
+    typealias TraceContext = MyTraceContext;
+    typealias Primitive = rt::TrianglePrimitive;
+    typealias Record = uint;
+}
+
+struct BadAnyHit : rt::IAnyHitShader<HitContext>
+{
+    void invoke(rt::AnyHitInput<HitContext> input)
+//CHECK: ^^^^^^ dependencies not compatible on stage
+//CHECK: ^^^^^^ 'invoke' requires support for stage 'anyhit', but stage is unsupported.
+    {
+        rt::RayTracer<Layout> tracer;
+        tracer.trace({}, scene, descriptor, input.payload);
+//CHECK:                                          ^^^^^^^ conflicting capability requirement
+//CHECK:                                          ^^^^^^^ 'payload' requires capability
+    }
+}
+
+struct HitGroup : rt::IHitGroup
+{
+    typealias Slot = rt::HitGroupSlot<0>;
+    typealias Context = HitContext;
+    typealias ClosestHit = rt::NoClosestHit<HitContext>;
+    typealias AnyHit = BadAnyHit;
+    typealias Intersection = rt::NoIntersection<HitContext>;
+}
+
+struct Layout : rt::ITraceProgramLayout
+{
+    typealias TraceContext = MyTraceContext;
+    typealias HitGroups = rt::HitGroupList<TraceContext, HitGroup>;
+    typealias MissGroups = rt::NoMissGroups<TraceContext>;
+    typealias CallableGroups = rt::NoCallableGroups<TraceContext>;
+}
+
+rt::AccelerationStructure scene;
+rt::TraceProgramDescriptor<Layout> descriptor;


### PR DESCRIPTION
Fix for shader-slang/slang#12740.

This adds a shader-side capability contract to `RayTracer.trace` so structural AnyHit, Intersection, and Callable implementations are rejected before IR linking. The Metal forms permit the logical ray-generation, closest-hit, and miss roles used by synthesized dispatch.

Validation:
- focused HLSL and Metal diagnostic test
- structural frontend suite: 44/44
- full checked-in structural suite: 200/200