### PR TITLE
Close structural intersection placeholder extension

### DIFF
--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/IMPLEMENTATION_PLAN.md
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/IMPLEMENTATION_PLAN.md
@@ -229,8 +229,10 @@ public interface IClosestHitShader<Context>
 ```
 
 Apply the corresponding requirement to _AnyHit_, _Intersection_, _Miss_, and _Callable_. Validate
-each `invoke` witness and its reachable helpers against that logical stage. The metadata-only
-`IIntersectionStage` remains stage-neutral so it can also represent `NoIntersection`.
+each `invoke` witness and its reachable helpers against that logical stage. The internal
+`IIntersectionStage` marker remains stage-neutral so it can represent either a real
+_Intersection_ implementation or the canonical `NoIntersection` placeholder without exposing a
+third user extension point.
 
 All stage inputs are compiler-provided, zero-storage property views. Payload, shader-record data,
 built-ins, primitive data, and intersection reporting are properties or methods mapped to

--- a/source/standard-modules/raytracing/stage-contracts.slang
+++ b/source/standard-modules/raytracing/stage-contracts.slang
@@ -17,8 +17,9 @@ public interface IAnyHitShader<Context>
     void invoke(AnyHitInput<Context> input);
 }
 
-// This stage-neutral marker also admits the built-in NoIntersection placeholder.
-public interface IIntersectionStage<Context>
+// This compiler-owned marker admits either IIntersectionShader or the built-in NoIntersection
+// placeholder without exposing a third extension point to user code.
+internal interface IIntersectionStage<Context>
     where Context : IHitContext
 {}
 

--- a/tests/ray-tracing-2/frontend/contracts/intersection-placeholder-closed.slang
+++ b/tests/ray-tracing-2/frontend/contracts/intersection-placeholder-closed.slang
@@ -1,0 +1,55 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -entry main -stage raygeneration -target hlsl
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -entry main -stage raygeneration -target metal
+
+import slang.raytracing;
+
+struct PayloadData {}
+struct Record {}
+
+struct MyTraceContext : rt::ITraceContext
+{
+    typealias Payload = PayloadData;
+    typealias AccelerationStructure = rt::AccelerationStructure;
+    typealias Motion = rt::NoMotion;
+}
+
+struct HitContext : rt::IHitContext
+{
+    typealias TraceContext = MyTraceContext;
+    typealias Primitive = rt::TrianglePrimitive;
+    typealias Record = Record;
+}
+
+struct FakeNoIntersection : rt::IIntersectionStage<HitContext> {}
+//CHECK:                        ^^^^^^^^^^^^^^^^^^ declaration not accessible
+//CHECK:                        ^^^^^^^^^^^^^^^^^^ 'IIntersectionStage' is not accessible from the current context.
+
+struct HitGroup : rt::IHitGroup
+//CHECK:              ^^^^^^^^^ type argument doesn't conform to interface
+//CHECK:              ^^^^^^^^^ type argument 'HitGroup' does not conform to the required interface 'rt.IHitGroup'
+{
+    typealias Slot = rt::HitGroupSlot<0>;
+    typealias Context = HitContext;
+    typealias ClosestHit = rt::NoClosestHit<HitContext>;
+    typealias AnyHit = rt::NoAnyHit<HitContext>;
+    typealias Intersection = FakeNoIntersection;
+}
+
+struct Layout : rt::ITraceProgramLayout
+{
+    typealias TraceContext = MyTraceContext;
+    typealias HitGroups = rt::HitGroupList<TraceContext, HitGroup>;
+    typealias MissGroups = rt::NoMissGroups<TraceContext>;
+    typealias CallableGroups = rt::NoCallableGroups<TraceContext>;
+}
+
+rt::AccelerationStructure scene;
+rt::TraceProgramDescriptor<Layout> descriptor;
+
+[shader("raygeneration")]
+void main()
+{
+    PayloadData payload;
+    rt::RayTracer<Layout> tracer;
+    tracer.trace({}, scene, descriptor, payload);
+}


### PR DESCRIPTION
Fix for shader-slang/slang#12742.

`IIntersectionStage` is an implementation marker whose only valid public producers are `IIntersectionShader` and the canonical `NoIntersection` placeholder. Making it internal prevents user-defined empty marker conformances from reaching layout IR generation without an `invoke` witness.

Validation:
- focused invalid-placeholder diagnostics on HLSL and Metal
- full checked-in structural suite: 202/202