### PR TITLE
Seal structural primitive markers

### DIFF
--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/IMPLEMENTATION_PLAN.md
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/IMPLEMENTATION_PLAN.md
@@ -245,6 +245,10 @@ semantics. Add a new IR operation only for state or behavior with no existing re
 Generic constraints enforce context, payload, primitive, attribute, and group agreement. Full-layout
 validation is limited to facts unavailable until group packs and slots are concrete.
 
+The primitive marker interfaces are sealed. Applications select `TrianglePrimitive`,
+`CurvePrimitive`, or `BoundingBoxPrimitive<Attributes>` so every accepted primitive has a defined
+native target mapping.
+
 ### 3.2 Structural Use Rules
 
 These restrictions are hard semantic errors and remain active under `-ignore-capabilities`.

--- a/source/standard-modules/raytracing/ray-types.slang
+++ b/source/standard-modules/raytracing/ray-types.slang
@@ -109,11 +109,15 @@ public struct CurveData
     }
 }
 
+// These sealed markers keep the public primitive set closed. Applications select one of the
+// public primitive types below instead of introducing an unsupported native geometry kind.
+[sealed]
 public interface IIntersectionPrimitive
 {
     associatedtype Attributes;
 }
 
+[sealed]
 public interface ICustomIntersectionPrimitive : IIntersectionPrimitive {}
 
 public struct TrianglePrimitive : IIntersectionPrimitive

--- a/tests/ray-tracing-2/frontend/contracts/primitive-marker-closed.slang
+++ b/tests/ray-tracing-2/frontend/contracts/primitive-marker-closed.slang
@@ -1,0 +1,60 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -entry main -stage raygeneration -target hlsl
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -entry main -stage raygeneration -target metal
+
+import slang.raytracing;
+
+struct FakePrimitive : rt::IIntersectionPrimitive
+//CHECK:                   ^^^^^^^^^^^^^^^^^^^^^^ cannot inherit from type 'rt.IIntersectionPrimitive' marked 'sealed' in module 'raytracing'
+{
+    typealias Attributes = float2;
+}
+
+struct PayloadData {}
+struct Record {}
+
+struct MyTraceContext : rt::ITraceContext
+{
+    typealias Payload = PayloadData;
+    typealias AccelerationStructure = rt::AccelerationStructure;
+    typealias Motion = rt::NoMotion;
+}
+
+struct HitContext : rt::IHitContext
+{
+    typealias TraceContext = MyTraceContext;
+    typealias Primitive = FakePrimitive;
+    typealias Record = Record;
+}
+
+struct ClosestHitStage : rt::IClosestHitShader<HitContext>
+{
+    void invoke(rt::ClosestHitInput<HitContext> input) {}
+}
+
+struct HitGroup : rt::IHitGroup
+{
+    typealias Slot = rt::HitGroupSlot<0>;
+    typealias Context = HitContext;
+    typealias ClosestHit = ClosestHitStage;
+    typealias AnyHit = rt::NoAnyHit<HitContext>;
+    typealias Intersection = rt::NoIntersection<HitContext>;
+}
+
+struct Layout : rt::ITraceProgramLayout
+{
+    typealias TraceContext = MyTraceContext;
+    typealias HitGroups = rt::HitGroupList<TraceContext, HitGroup>;
+    typealias MissGroups = rt::NoMissGroups<TraceContext>;
+    typealias CallableGroups = rt::NoCallableGroups<TraceContext>;
+}
+
+rt::AccelerationStructure scene;
+rt::TraceProgramDescriptor<Layout> descriptor;
+
+[shader("raygeneration")]
+void main()
+{
+    PayloadData payload;
+    rt::RayTracer<Layout> tracer;
+    tracer.trace({}, scene, descriptor, payload);
+}


### PR DESCRIPTION
Fix for shader-slang/slang#12743.

The public primitive choices already provide every supported geometry mapping. Sealing their compiler-owned marker interfaces rejects application-defined primitive kinds before IR and target lowering while preserving the associated `Attributes` contract.

Validation:
- focused HLSL and Metal invalid-primitive diagnostics
- full checked-in structural suite: 204/204