### PR TITLE
Seal structural group list markers

### DIFF
--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/IMPLEMENTATION_PLAN.md
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/IMPLEMENTATION_PLAN.md
@@ -249,6 +249,9 @@ The primitive marker interfaces are sealed. Applications select `TrianglePrimiti
 `CurvePrimitive`, or `BoundingBoxPrimitive<Attributes>` so every accepted primitive has a defined
 native target mapping.
 
+The group-list interfaces are also sealed. Their canonical variadic and empty implementations keep
+the concrete group pack available to layout discovery.
+
 ### 3.2 Structural Use Rules
 
 These restrictions are hard semantic errors and remain active under `-ignore-capabilities`.

--- a/source/standard-modules/raytracing/program-layout.slang
+++ b/source/standard-modules/raytracing/program-layout.slang
@@ -40,18 +40,21 @@ public interface ICallableGroup
     associatedtype Callable : ICallableShader<Context>;
 }
 
+[sealed]
 public interface IHitGroupList<TraceContext>
     where TraceContext : ITraceContext
 {
     static const int count;
 }
 
+[sealed]
 public interface IMissGroupList<TraceContext>
     where TraceContext : ITraceContext
 {
     static const int count;
 }
 
+[sealed]
 public interface ICallableGroupList<TraceContext>
     where TraceContext : ITraceContext
 {

--- a/tests/ray-tracing-2/frontend/contracts/group-list-markers-closed.slang
+++ b/tests/ray-tracing-2/frontend/contracts/group-list-markers-closed.slang
@@ -1,0 +1,50 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -entry main -stage raygeneration -target hlsl
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -entry main -stage raygeneration -target metal
+
+import slang.raytracing;
+
+struct PayloadData {}
+
+struct MyTraceContext : rt::ITraceContext
+{
+    typealias Payload = PayloadData;
+    typealias AccelerationStructure = rt::AccelerationStructure;
+    typealias Motion = rt::NoMotion;
+}
+
+struct FakeHitGroups : rt::IHitGroupList<MyTraceContext>
+//CHECK:                   ^^^^^^^^^^^^^ cannot inherit from type 'rt.IHitGroupList<MyTraceContext>' marked 'sealed' in module 'raytracing'
+{
+    static const int count = 1;
+}
+
+struct FakeMissGroups : rt::IMissGroupList<MyTraceContext>
+//CHECK:                    ^^^^^^^^^^^^^^ cannot inherit from type 'rt.IMissGroupList<MyTraceContext>' marked 'sealed' in module 'raytracing'
+{
+    static const int count = 1;
+}
+
+struct FakeCallableGroups : rt::ICallableGroupList<MyTraceContext>
+//CHECK:                        ^^^^^^^^^^^^^^^^^^ cannot inherit from type 'rt.ICallableGroupList<MyTraceContext>' marked 'sealed' in module 'raytracing'
+{
+    static const int count = 1;
+}
+
+struct Layout : rt::ITraceProgramLayout
+{
+    typealias TraceContext = MyTraceContext;
+    typealias HitGroups = FakeHitGroups;
+    typealias MissGroups = rt::NoMissGroups<TraceContext>;
+    typealias CallableGroups = rt::NoCallableGroups<TraceContext>;
+}
+
+rt::AccelerationStructure scene;
+rt::TraceProgramDescriptor<Layout> descriptor;
+
+[shader("raygeneration")]
+void main()
+{
+    PayloadData payload;
+    rt::RayTracer<Layout> tracer;
+    tracer.trace({}, scene, descriptor, payload);
+}


### PR DESCRIPTION
Fix for shader-slang/slang#12744.

Only the canonical variadic and empty list implementations preserve a group pack the compiler can enumerate. Sealing the three list marker interfaces prevents a custom nonzero `count` from compiling as an empty layout.

Validation:
- focused HLSL and Metal diagnostics for hit, miss, and callable list markers
- full checked-in structural suite: 206/206