### PR TITLE
Seal structural motion markers

### DIFF
--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/PROPOSAL.md
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/PROPOSAL.md
@@ -698,16 +698,22 @@ interface ITraceContext
 The motion type selects one trace-wide motion mode:
 
 ```slang
+[sealed]
+interface IRayMotion {}
+
+[sealed]
+interface IEnabledRayMotion : IRayMotion {}
+
 struct NoMotion : IRayMotion {}
 
 [require(metallib_2_4)]
-struct PrimitiveMotion : IRayMotion {}
+struct PrimitiveMotion : IEnabledRayMotion {}
 
 [require(metallib_2_4)]
-struct InstanceMotion : IRayMotion {}
+struct InstanceMotion : IEnabledRayMotion {}
 
 [require(metallib_2_4)]
-struct PrimitiveAndInstanceMotion : IRayMotion {}
+struct PrimitiveAndInstanceMotion : IEnabledRayMotion {}
 ```
 
 A hit group context specializes the trace context with a primitive kind and a record type:

--- a/source/standard-modules/raytracing/ray-types.slang
+++ b/source/standard-modules/raytracing/ray-types.slang
@@ -3,8 +3,10 @@ implementing raytracing;
 namespace rt
 {
 
+[sealed]
 public interface IRayMotion {}
 
+[sealed]
 public interface IEnabledRayMotion : IRayMotion {}
 
 public struct NoMotion : IRayMotion {}

--- a/tests/ray-tracing-2/frontend/contracts/motion-marker-closed.slang
+++ b/tests/ray-tracing-2/frontend/contracts/motion-marker-closed.slang
@@ -1,0 +1,12 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -target hlsl
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -target metal
+
+import slang.raytracing;
+
+struct CustomMotion : rt::IRayMotion
+//CHECK:                  ^^^^^^^^^^ cannot inherit from type 'rt.IRayMotion' marked 'sealed' in module 'raytracing'
+{}
+
+struct CustomEnabledMotion : rt::IEnabledRayMotion
+//CHECK:                         ^^^^^^^^^^^^^^^^^ cannot inherit from type 'rt.IEnabledRayMotion' marked 'sealed' in module 'raytracing'
+{}


### PR DESCRIPTION
Fix for shader-slang/slang#12746.

The structural motion axis has four compiler-known modes, so seal `IRayMotion` and `IEnabledRayMotion` against unsupported external conformances. This turns a target-lowering crash into an early semantic diagnostic and documents the closed contract in the proposal.

Validation:
- focused HLSL and Metal diagnostic coverage
- all 208 previously checked-in `tests/ray-tracing-2` directives plus the two new diagnostics pass on Linux