### PR TITLE
Reject generic structural runtime results

### DIFF
--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/IMPLEMENTATION_PLAN.md
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/IMPLEMENTATION_PLAN.md
@@ -265,6 +265,9 @@ These restrictions are hard semantic errors and remain active under `-ignore-cap
 | `TraceProgramDescriptor<Layout>`           | Opaque resource binding and trace argument                                                    | Shader construction, field access, or copies outside opaque-resource rules                           |
 | `RayTracer<Layout>`                        | Local zero-storage facade                                                                     | Calling `trace` from a stage where tracing is unavailable                                            |
 
+Apply the same runtime-type checks after generic invocation is resolved so specialization cannot
+hide a structural stage, stage-input, or metadata result.
+
 The descriptor type itself is stage-neutral. `RayTracer.trace` uses the same stage capability as the
 existing `TraceRay` operation, preserving recursive traces from _ClosestHit_ and _Miss_.
 

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -4265,6 +4265,9 @@ Expr* SemanticsVisitor::CheckInvokeExprWithCheckedOperands(InvokeExpr* expr)
         if (expr->arguments.getCount() == 1 && invoke == expr->arguments[0])
             return rs;
 
+        if (diagnoseInvalidStructuralRayTracingInvokeResult(invoke))
+            return CreateErrorExpr(invoke);
+
         if (auto funcType = as<FuncType>(invoke->functionExpr->type))
         {
             if (!funcType->getErrorType()->equals(m_astBuilder->getBottomType()))

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -2601,6 +2601,7 @@ public:
     void diagnoseInvalidStructuralRayTracingCallableResult(CallableDecl* callableDecl);
     void diagnoseInvalidStructuralRayTracingPropertyType(PropertyDecl* propertyDecl);
     bool diagnoseInvalidStructuralRayTracingConstruction(InvokeExpr* invoke);
+    bool diagnoseInvalidStructuralRayTracingInvokeResult(InvokeExpr* invoke);
 
     void _checkDifferentialConformance(
         ConformanceCheckingContext* context,

--- a/source/slang/slang-check-structural-ray-tracing.cpp
+++ b/source/slang/slang-check-structural-ray-tracing.cpp
@@ -987,6 +987,16 @@ bool SemanticsVisitor::diagnoseInvalidStructuralRayTracingConstruction(InvokeExp
     return true;
 }
 
+bool SemanticsVisitor::diagnoseInvalidStructuralRayTracingInvokeResult(InvokeExpr* invoke)
+{
+    auto kind = _findStructuralRuntimeType(this, invoke->type);
+    if (kind == StructuralRayTracingRuntimeTypeKind::None)
+        return false;
+
+    _diagnoseInvalidStructuralRayTracingRuntimeType(this, kind, invoke->type, invoke->loc);
+    return true;
+}
+
 bool SemanticsVisitor::diagnoseDirectStructuralRayTracingStageInvoke(
     InvokeExpr* invoke,
     FunctionDeclBase* functionDecl)

--- a/tests/ray-tracing-2/frontend/diagnostics/generic-runtime-result.slang
+++ b/tests/ray-tracing-2/frontend/diagnostics/generic-runtime-result.slang
@@ -1,0 +1,41 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -ignore-capabilities -entry main -stage compute -target hlsl
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -ignore-capabilities -entry main -stage compute -target metal
+
+import slang.raytracing;
+
+struct TestPayload
+{
+    uint value;
+}
+
+struct TestRecord
+{}
+
+struct TestTraceContext : rt::ITraceContext
+{
+    typealias Payload = TestPayload;
+    typealias AccelerationStructure = rt::AccelerationStructure;
+    typealias Motion = rt::NoMotion;
+}
+
+struct HitContext : rt::IHitContext
+{
+    typealias TraceContext = TestTraceContext;
+    typealias Primitive = rt::TrianglePrimitive;
+    typealias Record = TestRecord;
+}
+
+T makeValue<T>()
+{
+    return T();
+}
+
+RWStructuredBuffer<uint> output;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    output[0] = makeValue<rt::ClosestHitInput<HitContext>>().payload.value;
+//CHECK:                                                  ^ storage of a structural ray-tracing stage input
+//CHECK:                                                  ^ ray-tracing stage input type 'rt.ClosestHitInput<HitContext>' is compiler-provided and may only be used as a value parameter
+}


### PR DESCRIPTION
Fix for shader-slang/slang#12747.

After overload resolution, classify the concrete result of every invocation and reject structural stage, stage-input, and metadata values. This closes generic specialization paths that bypass declaration-time checks and could emit a ray payload parameter on a compute entry point under `-ignore-capabilities`.

Validation:
- focused HLSL and Metal diagnostics with `-ignore-capabilities`
- all 212 checked-in/new `tests/ray-tracing-2` directives pass on Linux