### PR TITLE
Reject stage inputs as generic arguments

### DIFF
--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/IMPLEMENTATION_PLAN.md
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/IMPLEMENTATION_PLAN.md
@@ -259,14 +259,15 @@ These restrictions are hard semantic errors and remain active under `-ignore-cap
 
 | Kind                                       | Allowed                                                                                       | Rejected                                                                                             |
 | ------------------------------------------ | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Stage implementation                       | Stateless methods, conformance, type-only layout use, reflection, and compiler-selected entry | Instance fields, user construction, runtime storage, existential conversion, or direct `invoke` call |
-| Stage input                                | Compiler-provided `invoke` parameter and same-stage by-value helper flow                      | User construction, binding, storage, non-value parameter directions, return, or cross-stage use      |
+| Stage implementation                       | Stateless methods, conformance, type-only layout use, reflection, and compiler-selected entry | Instance fields, construction, runtime storage, existential conversion, or direct `invoke` calls     |
+| Stage input                                | Compiler-provided `invoke` parameter and direct same-stage value helpers                      | Construction, storage, generic arguments, non-value parameters, return, or cross-stage use           |
 | Slot, group, group list, or program layout | Associated types and static metadata                                                          | Runtime materialization                                                                              |
 | `TraceProgramDescriptor<Layout>`           | Opaque resource binding and trace argument                                                    | Shader construction, field access, or copies outside opaque-resource rules                           |
 | `RayTracer<Layout>`                        | Local zero-storage facade                                                                     | Calling `trace` from a stage where tracing is unavailable                                            |
 
 Apply the same runtime-type checks after generic invocation is resolved so specialization cannot
-hide a structural stage, stage-input, or metadata result.
+hide a structural stage, stage-input, or metadata result. Reject stage-input generic arguments so
+a specialization cannot construct or store a compiler-provided input internally.
 
 The descriptor type itself is stage-neutral. `RayTracer.trace` uses the same stage capability as the
 existing `TraceRay` operation, preserving recursive traces from _ClosestHit_ and _Miss_.

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -4268,6 +4268,9 @@ Expr* SemanticsVisitor::CheckInvokeExprWithCheckedOperands(InvokeExpr* expr)
         if (diagnoseInvalidStructuralRayTracingInvokeResult(invoke))
             return CreateErrorExpr(invoke);
 
+        if (diagnoseInvalidStructuralRayTracingGenericArguments(invoke))
+            return CreateErrorExpr(invoke);
+
         if (auto funcType = as<FuncType>(invoke->functionExpr->type))
         {
             if (!funcType->getErrorType()->equals(m_astBuilder->getBottomType()))

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -2602,6 +2602,7 @@ public:
     void diagnoseInvalidStructuralRayTracingPropertyType(PropertyDecl* propertyDecl);
     bool diagnoseInvalidStructuralRayTracingConstruction(InvokeExpr* invoke);
     bool diagnoseInvalidStructuralRayTracingInvokeResult(InvokeExpr* invoke);
+    bool diagnoseInvalidStructuralRayTracingGenericArguments(InvokeExpr* invoke);
 
     void _checkDifferentialConformance(
         ConformanceCheckingContext* context,

--- a/source/slang/slang-check-structural-ray-tracing.cpp
+++ b/source/slang/slang-check-structural-ray-tracing.cpp
@@ -852,6 +852,16 @@ static StructuralRayTracingRuntimeTypeKind _findStructuralRuntimeType(
     if (directKind != StructuralRayTracingRuntimeTypeKind::None)
         return directKind;
 
+    if (auto typePack = as<ConcreteTypePack>(type))
+    {
+        for (Index i = 0; i < typePack->getTypeCount(); ++i)
+        {
+            auto kind = _findStructuralRuntimeType(visitor, typePack->getElementType(i), seenDecls);
+            if (kind != StructuralRayTracingRuntimeTypeKind::None)
+                return kind;
+        }
+    }
+
     if (auto structType = as<DeclRefType>(type))
     {
         if (auto structDecl = structType->getDeclRef().as<StructDecl>().getDecl())
@@ -934,10 +944,10 @@ void SemanticsVisitor::diagnoseInvalidStructuralRayTracingVariableType(VarDeclBa
         return;
 
     auto paramDecl = as<ParamDecl>(varDecl);
-    auto isReadOnlyValueParameter =
-        paramDecl && !paramDecl->hasModifier<OutModifier>() &&
-        !paramDecl->hasModifier<RefModifier>() && !paramDecl->hasModifier<BorrowModifier>() &&
-        !paramDecl->hasModifier<HLSLPayloadModifier>();
+    auto isReadOnlyValueParameter = paramDecl && !paramDecl->hasModifier<OutModifier>() &&
+                                    !paramDecl->hasModifier<RefModifier>() &&
+                                    !paramDecl->hasModifier<BorrowModifier>() &&
+                                    !paramDecl->hasModifier<HLSLPayloadModifier>();
     if (kind == StructuralRayTracingRuntimeTypeKind::StageInput && isReadOnlyValueParameter &&
         _getDirectStageInputKind(getLinkage()->getStructuralRayTracingDeclRegistry(), type) !=
             StructuralRayTracingStageKind::Count)
@@ -994,6 +1004,89 @@ bool SemanticsVisitor::diagnoseInvalidStructuralRayTracingInvokeResult(InvokeExp
         return false;
 
     _diagnoseInvalidStructuralRayTracingRuntimeType(this, kind, invoke->type, invoke->loc);
+    return true;
+}
+
+static Type* _findStructuralStageInputInGenericArgument(
+    SemanticsVisitor* visitor,
+    Type* type,
+    HashSet<Type*>& seenTypes)
+{
+    type = type ? as<Type>(type->resolve()) : nullptr;
+    if (!type || !seenTypes.add(type))
+        return nullptr;
+
+    if (_findStructuralRuntimeType(visitor, type) ==
+        StructuralRayTracingRuntimeTypeKind::StageInput)
+    {
+        return type;
+    }
+
+    if (auto declRefType = as<DeclRefType>(type))
+    {
+        Type* result = nullptr;
+        SubstitutionSet(declRefType->getDeclRef())
+            .forEachGenericSubstitution(
+                [&](GenericDecl*, Val::OperandView<Val> arguments)
+                {
+                    for (auto argument : arguments)
+                    {
+                        auto argumentType = as<Type>(argument->resolve());
+                        if (!result && argumentType)
+                        {
+                            result = _findStructuralStageInputInGenericArgument(
+                                visitor,
+                                argumentType,
+                                seenTypes);
+                        }
+                    }
+                });
+        if (result)
+            return result;
+    }
+
+    if (auto typePack = as<ConcreteTypePack>(type))
+    {
+        for (Index i = 0; i < typePack->getTypeCount(); ++i)
+        {
+            if (auto result = _findStructuralStageInputInGenericArgument(
+                    visitor,
+                    typePack->getElementType(i),
+                    seenTypes))
+            {
+                return result;
+            }
+        }
+    }
+    return nullptr;
+}
+
+bool SemanticsVisitor::diagnoseInvalidStructuralRayTracingGenericArguments(InvokeExpr* invoke)
+{
+    auto functionDeclRef = as<DeclRefExpr>(invoke->functionExpr);
+    if (!functionDeclRef)
+        return false;
+
+    Type* invalidType = nullptr;
+    HashSet<Type*> seenTypes;
+    SubstitutionSet(functionDeclRef->declRef)
+        .forEachSubstitutionArg(
+            [&](Val* argument)
+            {
+                if (invalidType)
+                    return;
+                auto type = as<Type>(argument->resolve());
+                if (type)
+                    invalidType = _findStructuralStageInputInGenericArgument(this, type, seenTypes);
+            });
+    if (!invalidType)
+        return false;
+
+    _diagnoseInvalidStructuralRayTracingRuntimeType(
+        this,
+        StructuralRayTracingRuntimeTypeKind::StageInput,
+        invalidType,
+        invoke->functionExpr->loc);
     return true;
 }
 

--- a/tests/ray-tracing-2/frontend/diagnostics/generic-stage-input-argument.slang
+++ b/tests/ray-tracing-2/frontend/diagnostics/generic-stage-input-argument.slang
@@ -1,0 +1,78 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -ignore-capabilities -entry main -stage compute -target hlsl
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature -ignore-capabilities -entry main -stage compute -target metal
+
+import slang.raytracing;
+
+struct TestPayload
+{
+    uint value;
+}
+
+struct TestRecord
+{}
+
+struct TestTraceContext : rt::ITraceContext
+{
+    typealias Payload = TestPayload;
+    typealias AccelerationStructure = rt::AccelerationStructure;
+    typealias Motion = rt::NoMotion;
+}
+
+struct HitContext : rt::IHitContext
+{
+    typealias TraceContext = TestTraceContext;
+    typealias Primitive = rt::TrianglePrimitive;
+    typealias Record = TestRecord;
+}
+
+void consume<T>(T value) {}
+
+struct ClosestHit : rt::IClosestHitShader<HitContext>
+{
+    void invoke(rt::ClosestHitInput<HitContext> input)
+    {
+        consume(input);
+//CHECK:^^^^^^^ storage of a structural ray-tracing stage input
+//CHECK:^^^^^^^ ray-tracing stage input type 'rt.ClosestHitInput<HitContext>' is compiler-provided and may only be used as a value parameter
+    }
+}
+
+interface IReadable
+{
+    uint read();
+}
+
+extension rt::ClosestHitInput<HitContext> : IReadable
+{
+    [require(closesthit)]
+    uint read()
+    {
+        return payload.value;
+    }
+}
+
+uint makeAndRead<T>()
+    where T : IReadable
+{
+    return T().read();
+}
+
+struct Wrapper<T> {}
+
+void useType<T>() {}
+
+RWStructuredBuffer<uint> output;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    output[0] = makeAndRead<rt::ClosestHitInput<HitContext>>();
+//CHECK:        ^^^^^^^^^^^ storage of a structural ray-tracing stage input
+//CHECK:        ^^^^^^^^^^^ ray-tracing stage input type 'rt.ClosestHitInput<HitContext>' is compiler-provided and may only be used as a value parameter
+
+    useType<Wrapper<rt::ClosestHitInput<HitContext>>>();
+/*CHECK:
+    ^^^^^^^ storage of a structural ray-tracing stage input
+    ^^^^^^^ ray-tracing stage input type 'rt.ClosestHitInput<HitContext>' is compiler-provided and may only be used as a value parameter
+*/
+}


### PR DESCRIPTION
Fix for shader-slang/slang#12748.

Inspect resolved generic substitutions at each runtime invocation and reject stage-input arguments, including inferred and nested arguments and concrete type packs. This prevents a specialization from constructing or storing a compiler-provided stage input internally while preserving explicit same-stage by-value helpers.

Validation:
- explicit, inferred, and nested HLSL/Metal diagnostics under `-ignore-capabilities`
- all 214 checked-in/new `tests/ray-tracing-2` directives pass on Linux